### PR TITLE
Implements dvote `getInfo`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/lib/pq v1.8.0
 	github.com/prometheus/client_golang v1.9.0
 	github.com/rubenv/sql-migrate v0.0.0-20200616145509-8d140a17f351
+	github.com/shirou/gopsutil v3.20.12+incompatible
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -52,6 +52,9 @@ func (m *Manager) RegisterMethods(path string) error {
 
 	log.Infof("adding namespace manager %s", path+"/manager")
 	transport.AddNamespace(path + "/manager")
+	if err := m.Router.AddHandler("getInfo", path+"/manager", m.Router.Info, false, true); err != nil {
+		return err
+	}
 	if err := m.Router.AddHandler("signUp", path+"/manager", m.signUp, false, false); err != nil {
 		return err
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -8,11 +8,20 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
+	psload "github.com/shirou/gopsutil/load"
+	psmem "github.com/shirou/gopsutil/mem"
+	psnet "github.com/shirou/gopsutil/net"
 	"github.com/vocdoni/multirpc/transports"
 	"go.vocdoni.io/dvote/crypto"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/manager/types"
+)
+
+const (
+	healthMemMax   = 100
+	healthLoadMax  = 10
+	healthSocksMax = 10000
 )
 
 type registeredMethod struct {
@@ -254,4 +263,62 @@ func (r *Router) SendError(request RouterRequest, errMsg string) {
 		}
 		request.Send(msg)
 	}
+}
+
+func (r *Router) Info(request RouterRequest) {
+	var response types.MetaResponse
+	response.APIList = []string{"registry"}
+	response.Request = request.id
+	if health, err := getHealth(); err == nil {
+		response.Health = health
+	} else {
+		response.Health = -1
+		log.Errorf("cannot get health status: (%s)", err)
+	}
+	request.Send(r.BuildReply(&request, &response))
+}
+
+// Health is a number between 0 and 99 that represents the status of the node, as bigger the better
+// The formula ued to calculate health is: 100* (1- ( Sum(weight[0..1] * value/value_max) ))
+// Weight is a number between 0 and 1 used to give a specific weight to a value. The sum of all weights used must be equals to 1
+//  so 0.2*value1 + 0.8*value2 would give 20% of weight to value1 and 80% of weight to value2
+// Each value must be represented as a number between 0 and 1. To this aim the value might be divided by its maximum value
+//  so if the mettered value is cpuLoad, a maximum must be defined in order to give a normalized value between 0 and 1
+//   i.e cpuLoad=2 and maxCpuLoad=10. The value is: 2/10 (where cpuLoad<10) = 0.2
+// The last operation includes the reverse of the values, so 1- (result).
+//   And its *100 multiplication and trunking in order to provide a natural number between 0 and 99
+func getHealth() (int32, error) {
+	v, err := psmem.VirtualMemory()
+	if err != nil {
+		return 0, err
+	}
+	memUsed := v.UsedPercent
+	l, err := psload.Avg()
+	if err != nil {
+		return 0, err
+	}
+	load15 := l.Load15
+	n, err := psnet.Connections("tcp")
+	if err != nil {
+		return 0, err
+	}
+	sockets := float64(len(n))
+
+	// ensure maximums are not overflow
+	if memUsed > healthMemMax {
+		memUsed = healthMemMax
+	}
+	if load15 > healthLoadMax {
+		load15 = healthLoadMax
+	}
+	if sockets > healthSocksMax {
+		sockets = healthSocksMax
+	}
+	result := int32((1 - (0.33*(memUsed/healthMemMax) +
+		0.33*(load15/healthLoadMax) +
+		0.33*(sockets/healthSocksMax))) * 100)
+	if result < 0 || result >= 100 {
+		return 0, fmt.Errorf("expected health to be between 0 and 99: %d", result)
+	}
+	return result, nil
 }

--- a/types/api.go
+++ b/types/api.go
@@ -58,11 +58,13 @@ type ResponseMessage struct {
 // Fields must be in alphabetical order
 // Those fields with valid zero-values (such as bool) must be pointers
 type MetaResponse struct {
+	APIList    []string    `json:"apiList,omitempty"`
 	Census     *Census     `json:"census,omitempty"`
 	Censuses   []Census    `json:"censuses,omitempty"`
 	Claims     [][]byte    `json:"claims,omitempty"`
 	Count      int         `json:"count,omitempty"`
 	Entity     *Entity     `json:"entity,omitempty"`
+	Health     int32       `json:"health,omitempty"`
 	InvalidIDs []uuid.UUID `json:"invalidIds,omitempty"`
 	//TODO InvalidKeys HexBytes when API supports protobuf or similar
 	InvalidKeys   []string     `json:"invalidKeys,omitempty"`


### PR DESCRIPTION
@p4u In the end the request is server under the `api/manager` endpoint. 
This endpoint is used by the frontend to instantiate the `dvote-js` gateway object, and it makes sense to use the same endpoint for the "health" validation and the actual  requests, since in any other case we would need to modify the instantiated object.
As I understand in `go-dvote` the `getInfo` is also unde the `dvote` endpoint.

The implementation of the actual `info` request, seemed suitable in the router module, since it can be reused by other endpoints.