### PR TITLE
Remove unnecessary /api sufix in traefik configuration

### DIFF
--- a/misc/compose/docker-compose.yml
+++ b/misc/compose/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - db
     labels:
       traefik.enable: true
-      traefik.frontend.rule: "PathPrefix:/api"
+      traefik.frontend.rule: "PathPrefix:/"
       traefik.default.port: 8000
       traefik.default.protocol: http
     <<: *log-config


### PR DESCRIPTION
This unnecessary `/api` suffix was breaking all the other routes not prefixed with `/api` (like `/ping`).